### PR TITLE
Add AWS Compute blog post

### DIFF
--- a/week-in-review/2016/09/week-in-review-2016-09-12.html
+++ b/week-in-review/2016/09/week-in-review-2016-09-12.html
@@ -9,6 +9,7 @@ September 12</td>
   <ul>
     <li><a href="https://twitter.com/johncmckim">John McKim</a> wrote about <a href="https://serverless.zone/slack-webhooks-with-the-serverless-framework-4c01bb3c1411">Slack Webhooks with the Serverless Framework</a> on AWS.</li>
     <li><a href="https://twitter.com/briskmad">Darin Briskman</a> wrote about <a href="https://aws.amazon.com/blogs/database/creating-a-simple-autocompletion-service-with-redis-part-one-of-two/">Creating a Simple Autocompletion Service with Redis: Part One of Two</a></li>
+    <li>The [computeblog] wrote about <a href="https://aws.amazon.com/blogs/compute/centralized-container-logs-with-amazon-ecs-and-amazon-cloudwatch-logs/">Centralized Container Logs with Amazon ECS and Amazon CloudWatch Logs</a></li>
   </ul>
 </td>
 </tr>


### PR DESCRIPTION
On Centralized Container Logs with Amazon ECS and Amazon CloudWatch Logs
