### PR TITLE
Add Hudi/Loft Event and Greenhouse Blog Post

### DIFF
--- a/week-in-review/2016/09/week-in-review-2016-09-12.html
+++ b/week-in-review/2016/09/week-in-review-2016-09-12.html
@@ -26,7 +26,7 @@ September 13</td>
     <li><a href="https://github.com/bbayles">Bo Bayles</a> wrote about using Inspector and VPC Flow Logs for security monitoring at the <a href="https://observable.net/blog/managing-amazon-inspector-for-more-secure-ec2-environments/">Observable Networks blog</a>.</li>
     <li><a href="http://blog.rowanudell.com/">Rowan Udell</a> wrote about <a href="http://blog.rowanudell.com/testing-serverless-functions-locally/">testing Serverless (Lambda) functions locally</a>.</li>
     <li><a href="https://www.linkedin.com/in/larky">Andrew Larkin</a> presented a new Cloud Academy webinar: <a href="https://cloudacademy.com/webinars/cloud-academy-office-hours-aws-certifications-special-guest-25/">AWS Certifications Special Guest - Greg Cockburn</a>.</li>
-    <li><a href="https://twitter.com/mkosut">Mackenzie Kosut</a> wrote about <a href="https://medium.com/aws-activate-startup-blog/greenhouse-of-the-future-with-aws-iot-and-intel-edison-19890eca4837#.stmucz97h">Greenhouse of the future with AWS IoT and Intel Edison</a>.</li>
+    <li><a href="https://twitter.com/mkosut">Mackenzie Kosut</a> wrote about <a href="https://medium.com/aws-activate-startup-blog/greenhouse-of-the-future-with-aws-iot-and-intel-edison-19890eca4837#.stmucz97h">Greenhouse of the future with AWS IoT and Intel Edison</a> on our [startupblog].</li>
   </ul>
 </td>
 </tr>

--- a/week-in-review/2016/09/week-in-review-2016-09-12.html
+++ b/week-in-review/2016/09/week-in-review-2016-09-12.html
@@ -37,7 +37,7 @@ September 13</td>
 September 14</td>
 <td>
 <ul>
-    <li><a href="https://twitter.com/Hudi">Hudi</a>'s CTO spoke at the <a href='https://aws.amazon.com/start-ups/loft/ny-loft/?sc_channel=sm&sc_campaign=nyloftweektwitterpromo_090916&sc_publisher=tw&sc_country=us&sc_geo=namer&sc_outcome=startup&adbsc=startups_20160909_65538696&adbid=774261151978758144&adbpl=tw&adbpr=168826960'>AWS Pop-up Loft | New York on how they're helping the NBA &amp; NFL</a></li>
+    <li><a href="https://twitter.com/Hudl">Hudl</a>'s CTO spoke at the <a href='https://aws.amazon.com/start-ups/loft/ny-loft/?sc_channel=sm&sc_campaign=nyloftweektwitterpromo_090916&sc_publisher=tw&sc_country=us&sc_geo=namer&sc_outcome=startup&adbsc=startups_20160909_65538696&adbid=774261151978758144&adbpl=tw&adbpr=168826960'>AWS Pop-up Loft | New York on how they're helping the NBA &amp; NFL</a></li>
   </ul>
 </td>
 </tr>

--- a/week-in-review/2016/09/week-in-review-2016-09-12.html
+++ b/week-in-review/2016/09/week-in-review-2016-09-12.html
@@ -26,6 +26,7 @@ September 13</td>
     <li><a href="https://github.com/bbayles">Bo Bayles</a> wrote about using Inspector and VPC Flow Logs for security monitoring at the <a href="https://observable.net/blog/managing-amazon-inspector-for-more-secure-ec2-environments/">Observable Networks blog</a>.</li>
     <li><a href="http://blog.rowanudell.com/">Rowan Udell</a> wrote about <a href="http://blog.rowanudell.com/testing-serverless-functions-locally/">testing Serverless (Lambda) functions locally</a>.</li>
     <li><a href="https://www.linkedin.com/in/larky">Andrew Larkin</a> presented a new Cloud Academy webinar: <a href="https://cloudacademy.com/webinars/cloud-academy-office-hours-aws-certifications-special-guest-25/">AWS Certifications Special Guest - Greg Cockburn</a>.</li>
+    <li><a href="https://twitter.com/mkosut">Mackenzie Kosut</a> wrote about <a href="https://medium.com/aws-activate-startup-blog/greenhouse-of-the-future-with-aws-iot-and-intel-edison-19890eca4837#.stmucz97h">Greenhouse of the future with AWS IoT and Intel Edison</a>.</li>
   </ul>
 </td>
 </tr>
@@ -36,7 +37,7 @@ September 13</td>
 September 14</td>
 <td>
 <ul>
-    <li>???</li>
+    <li><a href="https://twitter.com/Hudi">Hudi</a>'s CTO spoke at the <a href='https://aws.amazon.com/start-ups/loft/ny-loft/?sc_channel=sm&sc_campaign=nyloftweektwitterpromo_090916&sc_publisher=tw&sc_country=us&sc_geo=namer&sc_outcome=startup&adbsc=startups_20160909_65538696&adbid=774261151978758144&adbpl=tw&adbpr=168826960'>AWS Pop-up Loft | New York on how they're helping the NBA &amp; NFL</a></li>
   </ul>
 </td>
 </tr>


### PR DESCRIPTION
Adding two entries for the AWS Startup team about Hudi CTO talk at the
NY loft, and the Greenhouse blog post w/ Intel
