### PR TITLE
adding link to blog for automating AWS CloudWatch on Ubuntu

### DIFF
--- a/week-in-review/2016/09/week-in-review-2016-09-12.html
+++ b/week-in-review/2016/09/week-in-review-2016-09-12.html
@@ -97,7 +97,7 @@ September 17</td>
 September 18</td>
 <td>
 <ul>
-    <li>???</li>
+    <li>The blog <a href="https://autozane.com">Autozane</a> provides an automated way of configuring and enabing <a href="https://autozane.com/automating-aws-cloudwatch-logs-on-ubuntu/">AWS CloudWatch Logs on Ubuntu using PackerIO and Terraform</a></li>
   </ul>
 </td>
 </tr>


### PR DESCRIPTION
adding link to blog for automating AWS CloudWatch on Ubuntu via PackerIO and Terraform
