### PR TITLE
Add Caching at Netflix Youtube video

### DIFF
--- a/week-in-review/2016/09/week-in-review-2016-09-12.html
+++ b/week-in-review/2016/09/week-in-review-2016-09-12.html
@@ -126,6 +126,7 @@ September 18</td>
 
 <span style="text-decoration: underline;"><strong>New YouTube Videos</strong></span>
 <ul style="padding-bottom: 1em;">
+  <li><a href="https://youtu.be/Rzdxgx3RC0Q">"Caching at Netflix: The Hidden Microservice" by Scott Mansfield</a></li>
   <li>???</li>
 </ul>
 


### PR DESCRIPTION
@jeffbarr 
Hi,
I'm not sure of the proper citation for a Youtube entry. I looked at the XML, but didn't get a clear idea. Apologies.

The caching described is within the AWS service scope, not the Netflix CDN cache.
