### PR TITLE
Added A Cloud Guru blog post to 2016-09-19

### DIFF
--- a/week-in-review/2016/09/week-in-review-2016-09-19.html
+++ b/week-in-review/2016/09/week-in-review-2016-09-19.html
@@ -7,7 +7,7 @@ Let's take a quick look at what happened in AWS-land last week:
 September 19</td>
 <td>
   <ul>
-    <li>???</li>
+    <li>The <a href="https://read.acloud.guru/">A Cloud Guru blog</a> wrote about <a href="https://read.acloud.guru/aws-partner-certification-distinction-why-aws-certification-is-more-valuable-than-ever-9aa46a7e0941">Why AWS Certification is more valuable than ever</li>
   </ul>
 </td>
 </tr>
@@ -112,4 +112,3 @@ September 25</td>
   <li><a href="http://aws.amazon.com/careers/">AWS Careers</a>.</li>
 </ul>
 Stay tuned for next week! In the meantime, <a href="https://twitter.com/jeffbarr" target="_self">follow me on Twitter</a> and <a href="http://feeds.feedburner.com/AmazonWebServicesBlog" target="_self">subscribe to the RSS feed</a>.
-


### PR DESCRIPTION
Mike Chambers wrote about the APN network recognising partners that certify staff members. He writes that this makes an AWS certification more valuable than ever.

https://read.acloud.guru/aws-partner-certification-distinction-why-aws-certification-is-more-valuable-than-ever-9aa46a7e0941
