### PR TITLE
Added link to @dkalintsev's blog on vADC in AWS

### DIFF
--- a/week-in-review/2016/09/week-in-review-2016-09-19.html
+++ b/week-in-review/2016/09/week-in-review-2016-09-19.html
@@ -7,7 +7,7 @@ Let's take a quick look at what happened in AWS-land last week:
 September 19</td>
 <td>
   <ul>
-    <li>???</li>
+    <li><a href="https://telecomoccasionally.wordpress.com/about/">Dmitri Kalintsev</a> wrote about <a href="https://telecomoccasionally.wordpress.com/2016/09/20/deploying-brocade-virtual-traffic-manager-cluster-in-aws-through-a-cloudformation-template/">Deploying Brocade Virtual Traffic Manager cluster in AWS through a CloudFormation template</a>.</li>
   </ul>
 </td>
 </tr>


### PR DESCRIPTION
Added link to my blog that walks through a CloudFormation template for building a redundant cluster of Brocade vADCs in AWS.
