### PR TITLE
Add Citus MX Post - Scaling Postgres to 500k writes/sec on AWS

### DIFF
--- a/week-in-review/2016/09/week-in-review-2016-09-19.html
+++ b/week-in-review/2016/09/week-in-review-2016-09-19.html
@@ -51,7 +51,7 @@ September 21</td>
 September 22</td>
 <td>
 <ul>
-    <li>???</li>
+    <li><a href="https://www.citusdata.com/">Citus Data</a> announced <a href="https://www.citusdata.com/blog/2016/09/22/announcing-citus-mx/">Citus MX on AWS: Scaling Postgres to over 500k writes per second</a></li>
   </ul>
 </td>
 </tr>


### PR DESCRIPTION
We just announced MX for Citus Cloud, doing 500k writes/second with Postgres, running on Amazon Web Services.

There's also a demo video here, happy to add if its of interest: https://www.youtube.com/watch?v=JAPl4eNFxk4
