### PR TITLE
Add AWS Price List API blog post link

### DIFF
--- a/week-in-review/2016/09/week-in-review-2016-09-19.html
+++ b/week-in-review/2016/09/week-in-review-2016-09-19.html
@@ -106,7 +106,7 @@ September 24</td>
 September 25</td>
 <td>
 <ul>
-    <li>???</li>
+    <li><a href="https://twitter.com/forrestbrazeal">Forrest Brazeal</a> wrote about <a href="https://forrestbrazeal.com/2016/09/25/adventures-in-aws-understanding-the-price-list-api/">how to look up running EC2 instances prices in the AWS Price List API</a>.</li>
   </ul>
 </td>
 </tr>


### PR DESCRIPTION
I wrote a blog post about how to look up running EC2 instance prices using the Price List API.
