### PR TITLE
Add Trainline microservices on AWS article

### DIFF
--- a/week-in-review/2016/10/week-in-review-2016-10-10.html
+++ b/week-in-review/2016/10/week-in-review-2016-10-10.html
@@ -7,7 +7,7 @@ Let's take a quick look at what happened in AWS-land last week:
 October 10</td>
 <td>
   <ul>
-    <li>???</li>
+    <li><a href="https://twitter.com/trainlineEngine">Trainline Engineering</a> wrote about <a href="https://engineering.thetrainline.com/2016/10/10/microservices-with-api-gateway-aws-lambda-and-jvm-languages/">Microservices with API Gateway, AWS Lambda and JVM languages</a></li>
   </ul>
 </td>
 </tr>
@@ -119,4 +119,3 @@ October 16</td>
   <li><a href="http://aws.amazon.com/careers/">AWS Careers</a>.</li>
 </ul>
 Stay tuned for next week! In the meantime, <a href="https://twitter.com/jeffbarr" target="_self">follow me on Twitter</a> and <a href="http://feeds.feedburner.com/AmazonWebServicesBlog" target="_self">subscribe to the RSS feed</a>.
-


### PR DESCRIPTION
Also deleted last, blank line, which possibly may still be wanted.
