### PR TITLE
Adds link to rds-pgbadger tool to list of Open Source applications

### DIFF
--- a/week-in-review/2016/10/week-in-review-2016-10-24.html
+++ b/week-in-review/2016/10/week-in-review-2016-10-24.html
@@ -90,7 +90,7 @@ October 30</td>
 
 <span style="text-decoration: underline;"><strong>New &amp; Notable Open Source</strong></span>
 <ul style="padding-bottom: 1em;">
-  <li>...</li>
+  <li><strong><a href="https://github.com/fpietka/rds-pgbadger">rds-pgbadger</a></strong> fetches log files from an Amazon RDS for PostgreSQL instance and generates a beautiful pgBadger report.</li>
 </ul>
 
 <span style="text-decoration: underline;"><strong>New SlideShare Presentations</strong></span>


### PR DESCRIPTION
Last week, I came across the very useful little tool rds-pgbadger (https://github.com/fpietka/rds-pgbadger). It simply takes an Amazon RDS for PostgreSQL instance name, and then downloads the log files from that instance and creates nice, graphical reports using the pgBadger (http://dalibo.github.io/pgbadger/, https://github.com/dalibo/pgbadger) log analyzer. 

With the default parameter group in Amazon RDS for PostgreSQL, the reports are not too useful. But it is easy to make a few changes to the parameters to get more detailed reports (the pgBadger documentation lists the relevant configuration settings).
