### PR TITLE
Add Serverless 1.1.0 release to 2016-10-31

### DIFF
--- a/week-in-review/2016/10/week-in-review-2016-10-31.html
+++ b/week-in-review/2016/10/week-in-review-2016-10-31.html
@@ -29,7 +29,7 @@ November 1</td>
 November 2</td>
 <td>
 <ul>
-    <li>???</li>
+    <li><a href="https://serverless.com">Serverless</a> released <a href="https://serverless.com/blog/serverless-v1.1.0/">V1.1.0</a> of the Serverless Framework to help you build applications with AWS and Lambda.</li>
   </ul>
 </td>
 </tr>
@@ -120,4 +120,3 @@ November 6</td>
   <li><a href="http://aws.amazon.com/careers/">AWS Careers</a>.</li>
 </ul>
 Stay tuned for next week! In the meantime, <a href="https://twitter.com/jeffbarr" target="_self">follow me on Twitter</a> and <a href="http://feeds.feedburner.com/AmazonWebServicesBlog" target="_self">subscribe to the RSS feed</a>.
-


### PR DESCRIPTION
Not sure if this should go in the open source part in the bottom of the document, but seems to me that is more for new open source projects? Happy to move there if its a better place.