### PR TITLE
Adding link to Shopify webhook article by Rewind

### DIFF
--- a/week-in-review/2016/11/week-in-review-2016-11-14.html
+++ b/week-in-review/2016/11/week-in-review-2016-11-14.html
@@ -20,7 +20,8 @@ November 14</td>
 November 15</td>
 <td>
 <ul>
-    <li>???</li>
+  <li><a href="https://rewindit.io">Rewind</a> wrote about <a href="https://medium.com/@mike_potter/handle-shopify-webhooks-without-a-server-ccd2ada62ece">how to handle Shopify webhooks using Lambda, API Gateway and SQS</a>.</li>
+    
   </ul>
 </td>
 </tr>


### PR DESCRIPTION
Added article about how to handle Shopify webhooks without a server.